### PR TITLE
Add start script to Scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "help"
+    "test": "help",
+    "start": "node ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added "start": "node ." to the scripts section allowing the use of 'npm start' to start the bot as opposed to node . or node index.js